### PR TITLE
Add autoselect tray

### DIFF
--- a/PPDs/xr6600dn.ppd
+++ b/PPDs/xr6600dn.ppd
@@ -79,15 +79,19 @@
 *UIConstraints: *Duplex *PageSize EnvC5
 
 *% Media size v/s Tray Constraints
+*UIConstraints: *PageSize Env10 *InputSlot AutoSelect
 *UIConstraints: *PageSize Env10 *InputSlot Tray1
 *UIConstraints: *PageSize Env10 *InputSlot Tray2
 
+*UIConstraints: *PageSize EnvMonarch *InputSlot AutoSelect
 *UIConstraints: *PageSize EnvMonarch *InputSlot Tray1
 *UIConstraints: *PageSize EnvMonarch *InputSlot Tray2
 
+*UIConstraints: *PageSize EnvDL *InputSlot AutoSelect
 *UIConstraints: *PageSize EnvDL *InputSlot Tray1
 *UIConstraints: *PageSize EnvDL *InputSlot Tray2
 
+*UIConstraints: *PageSize EnvC5 *InputSlot AutoSelect
 *UIConstraints: *PageSize EnvC5 *InputSlot Tray1
 *UIConstraints: *PageSize EnvC5 *InputSlot Tray2
 
@@ -193,9 +197,11 @@
 *UIConstraints :*MediaType Auto *PageSize EnvC5
 
 *%	Media type v/s  Tray Constraints
+*UIConstraints: *MediaType Envelope *InputSlot  AutoSelect
 *UIConstraints: *MediaType Envelope *InputSlot  Tray1
 *UIConstraints: *MediaType Envelope *InputSlot  Tray2
 
+*UIConstraints: *MediaType Labels *InputSlot  AutoSelect
 *UIConstraints: *MediaType Labels *InputSlot  Tray1
 *UIConstraints: *MediaType Labels *InputSlot  Tray2
 
@@ -316,7 +322,8 @@
 
 *OpenUI *InputSlot/InputSlot: PickOne
 *OrderDependency: 10 AnySetup *InputSlot
-*DefaultInputSlot: Tray1
+*DefaultInputSlot: AutoSelect
+*InputSlot AutoSelect/Auto: "<< (automatic) xerox$MediaInputTray >> setpagedevice"
 *InputSlot Tray1/Tray 1: "<< (tray-1) xerox$MediaInputTray >> setpagedevice"
 *InputSlot Tray2/Tray 2: "<< (tray-2) xerox$MediaInputTray >> setpagedevice"
 *InputSlot Bypass/Bypass Tray: "<< (bypass-tray) xerox$MediaInputTray >> setpagedevice"

--- a/PPDs/xr6605dn.ppd
+++ b/PPDs/xr6605dn.ppd
@@ -79,15 +79,19 @@
 *UIConstraints: *Duplex *PageSize EnvC5
 
 *% Media size v/s Tray Constraints
+*UIConstraints: *PageSize Env10 *InputSlot AutoSelect
 *UIConstraints: *PageSize Env10 *InputSlot Tray1
 *UIConstraints: *PageSize Env10 *InputSlot Tray2
 
+*UIConstraints: *PageSize EnvMonarch *InputSlot AutoSelect
 *UIConstraints: *PageSize EnvMonarch *InputSlot Tray1
 *UIConstraints: *PageSize EnvMonarch *InputSlot Tray2
 
+*UIConstraints: *PageSize EnvDL *InputSlot AutoSelect
 *UIConstraints: *PageSize EnvDL *InputSlot Tray1
 *UIConstraints: *PageSize EnvDL *InputSlot Tray2
 
+*UIConstraints: *PageSize EnvC5 *InputSlot AutoSelect
 *UIConstraints: *PageSize EnvC5 *InputSlot Tray1
 *UIConstraints: *PageSize EnvC5 *InputSlot Tray2
 
@@ -193,9 +197,11 @@
 *UIConstraints :*MediaType Auto *PageSize EnvC5
 
 *%	Media type v/s  Tray Constraints
+*UIConstraints: *MediaType Envelope *InputSlot  AutoSelect
 *UIConstraints: *MediaType Envelope *InputSlot  Tray1
 *UIConstraints: *MediaType Envelope *InputSlot  Tray2
 
+*UIConstraints: *MediaType Labels *InputSlot  AutoSelect
 *UIConstraints: *MediaType Labels *InputSlot  Tray1
 *UIConstraints: *MediaType Labels *InputSlot  Tray2
 
@@ -316,7 +322,8 @@
 
 *OpenUI *InputSlot/InputSlot: PickOne
 *OrderDependency: 10 AnySetup *InputSlot
-*DefaultInputSlot: Tray1
+*DefaultInputSlot: AutoSelect
+*InputSlot AutoSelect/Auto: "<< (automatic) xerox$MediaInputTray >> setpagedevice"
 *InputSlot Tray1/Tray 1: "<< (tray-1) xerox$MediaInputTray >> setpagedevice"
 *InputSlot Tray2/Tray 2: "<< (tray-2) xerox$MediaInputTray >> setpagedevice"
 *InputSlot Bypass/Bypass Tray: "<< (bypass-tray) xerox$MediaInputTray >> setpagedevice"

--- a/PPDs/xrx6600n.ppd
+++ b/PPDs/xrx6600n.ppd
@@ -73,15 +73,19 @@
 *% UI Constraints
 
 *% Media size v/s Tray Constraints
+*UIConstraints: *PageSize Env10 *InputSlot AutoSelect
 *UIConstraints: *PageSize Env10 *InputSlot Tray1
 *UIConstraints: *PageSize Env10 *InputSlot Tray2
 
+*UIConstraints: *PageSize EnvMonarch *InputSlot AutoSelect
 *UIConstraints: *PageSize EnvMonarch *InputSlot Tray1
 *UIConstraints: *PageSize EnvMonarch *InputSlot Tray2
 
+*UIConstraints: *PageSize EnvDL *InputSlot AutoSelect
 *UIConstraints: *PageSize EnvDL *InputSlot Tray1
 *UIConstraints: *PageSize EnvDL *InputSlot Tray2
 
+*UIConstraints: *PageSize EnvC5 *InputSlot AutoSelect
 *UIConstraints: *PageSize EnvC5 *InputSlot Tray1
 *UIConstraints: *PageSize EnvC5 *InputSlot Tray2
 
@@ -187,9 +191,11 @@
 *UIConstraints :*MediaType Auto *PageSize EnvC5
 
 *%	Media type v/s  Tray Constraints
+*UIConstraints: *MediaType Envelope *InputSlot  AutoSelect
 *UIConstraints: *MediaType Envelope *InputSlot  Tray1
 *UIConstraints: *MediaType Envelope *InputSlot  Tray2
 
+*UIConstraints: *MediaType Labels *InputSlot  AutoSelect
 *UIConstraints: *MediaType Labels *InputSlot  Tray1
 *UIConstraints: *MediaType Labels *InputSlot  Tray2
 
@@ -301,7 +307,8 @@
 
 *OpenUI *InputSlot/InputSlot: PickOne
 *OrderDependency: 10 AnySetup *InputSlot
-*DefaultInputSlot: Tray1
+*DefaultInputSlot: AutoSelect
+*InputSlot AutoSelect/Auto: "<< (automatic) xerox$MediaInputTray >> setpagedevice"
 *InputSlot Tray1/Tray 1: "<< (tray-1) xerox$MediaInputTray >> setpagedevice"
 *InputSlot Tray2/Tray 2: "<< (tray-2) xerox$MediaInputTray >> setpagedevice"
 *InputSlot Bypass/Bypass Tray: "<< (bypass-tray) xerox$MediaInputTray >> setpagedevice"

--- a/PPDs/xrx6605n.ppd
+++ b/PPDs/xrx6605n.ppd
@@ -73,15 +73,19 @@
 *% UI Constraints
 
 *% Media size v/s Tray Constraints
+*UIConstraints: *PageSize Env10 *InputSlot AutoSelect
 *UIConstraints: *PageSize Env10 *InputSlot Tray1
 *UIConstraints: *PageSize Env10 *InputSlot Tray2
 
+*UIConstraints: *PageSize EnvMonarch *InputSlot AutoSelect
 *UIConstraints: *PageSize EnvMonarch *InputSlot Tray1
 *UIConstraints: *PageSize EnvMonarch *InputSlot Tray2
 
+*UIConstraints: *PageSize EnvDL *InputSlot AutoSelect
 *UIConstraints: *PageSize EnvDL *InputSlot Tray1
 *UIConstraints: *PageSize EnvDL *InputSlot Tray2
 
+*UIConstraints: *PageSize EnvC5 *InputSlot AutoSelect
 *UIConstraints: *PageSize EnvC5 *InputSlot Tray1
 *UIConstraints: *PageSize EnvC5 *InputSlot Tray2
 
@@ -187,9 +191,11 @@
 *UIConstraints :*MediaType Auto *PageSize EnvC5
 
 *%	Media type v/s  Tray Constraints
+*UIConstraints: *MediaType Envelope *InputSlot  AutoSelect
 *UIConstraints: *MediaType Envelope *InputSlot  Tray1
 *UIConstraints: *MediaType Envelope *InputSlot  Tray2
 
+*UIConstraints: *MediaType Labels *InputSlot  AutoSelect
 *UIConstraints: *MediaType Labels *InputSlot  Tray1
 *UIConstraints: *MediaType Labels *InputSlot  Tray2
 
@@ -301,7 +307,8 @@
 
 *OpenUI *InputSlot/InputSlot: PickOne
 *OrderDependency: 10 AnySetup *InputSlot
-*DefaultInputSlot: Tray1
+*DefaultInputSlot: AutoSelect
+*InputSlot AutoSelect/Auto: "<< (automatic) xerox$MediaInputTray >> setpagedevice"
 *InputSlot Tray1/Tray 1: "<< (tray-1) xerox$MediaInputTray >> setpagedevice"
 *InputSlot Tray2/Tray 2: "<< (tray-2) xerox$MediaInputTray >> setpagedevice"
 *InputSlot Bypass/Bypass Tray: "<< (bypass-tray) xerox$MediaInputTray >> setpagedevice"


### PR DESCRIPTION
Just a small addition to the PPDs you fixed to enable autoselection of trays (and thus allow the printer to proceed on format conflicts depending on the corresponding printer setting). 

Thanks a lot by the way for preparing those PPDs - they helped me a lot when I tried get my printer running on Linux!

I hope I found my way correctly through this fork-edit-merge procedure of github :-)